### PR TITLE
Hide `main` branches from `brew tap-info` and `brew info`

### DIFF
--- a/Library/Homebrew/cmd/tap-info.rb
+++ b/Library/Homebrew/cmd/tap-info.rb
@@ -63,6 +63,8 @@ module Homebrew
           puts info
         else
           info = ""
+          default_branches = %w[main master].freeze
+
           taps.each_with_index do |tap, i|
             puts unless i.zero?
             info = "#{tap}: "
@@ -79,7 +81,7 @@ module Homebrew
               info += "\norigin: #{tap.remote}" if tap.remote != tap.default_remote
               info += "\nHEAD: #{tap.git_head || "(none)"}"
               info += "\nlast commit: #{tap.git_last_commit || "never"}"
-              info += "\nbranch: #{tap.git_branch || "(none)"}" if tap.git_branch != "master"
+              info += "\nbranch: #{tap.git_branch || "(none)"}" if default_branches.exclude?(tap.git_branch)
             else
               info += "Not installed"
             end

--- a/Library/Homebrew/system_config.rb
+++ b/Library/Homebrew/system_config.rb
@@ -128,7 +128,8 @@ module SystemConfig
         out.puts "#{tap_name} origin: #{tap.remote}" if tap.remote != tap.default_remote
         out.puts "#{tap_name} HEAD: #{tap.git_head || "(none)"}"
         out.puts "#{tap_name} last commit: #{tap.git_last_commit || "never"}"
-        out.puts "#{tap_name} branch: #{tap.git_branch || "(none)"}" if tap.git_branch != "master"
+        default_branches = %w[main master].freeze
+        out.puts "#{tap_name} branch: #{tap.git_branch || "(none)"}" if default_branches.exclude?(tap.git_branch)
       end
 
       if (json_file = Homebrew::API::HOMEBREW_CACHE_API/json_file_name) && json_file.exist?


### PR DESCRIPTION
These are basically as "default" as `master` now so we can hide them.